### PR TITLE
Organise tkinter imports

### DIFF
--- a/guizero/App.py
+++ b/guizero/App.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Tk
 
 from . import utilities as utils
 

--- a/guizero/Box.py
+++ b/guizero/Box.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Frame
 
 from . import utilities as utils
     

--- a/guizero/ButtonGroup.py
+++ b/guizero/ButtonGroup.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Frame, StringVar
 
 from . import utilities as utils
 from .Box import Box

--- a/guizero/CheckBox.py
+++ b/guizero/CheckBox.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Checkbutton
 
 from . import utilities as utils
     

--- a/guizero/Combo.py
+++ b/guizero/Combo.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import OptionMenu, StringVar
 
 from . import utilities as utils
     

--- a/guizero/MenuBar.py
+++ b/guizero/MenuBar.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Menu
 
 from . import utilities as utils
 from .App import App

--- a/guizero/Picture.py
+++ b/guizero/Picture.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Label, PhotoImage
 
 from . import utilities as utils
 
@@ -9,7 +6,7 @@ from . import utilities as utils
 #try:
 #    from PIL import Image, ImageTk
 #except ImportError:
-    #utils.error_format("You will only be able to display GIF images as you do not have the PIL library.")
+#    utils.error_format("You will only be able to display GIF images as you do not have the PIL library.")
 
 
 class Picture(Label):

--- a/guizero/PushButton.py
+++ b/guizero/PushButton.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Button, PhotoImage
 
 from . import utilities as utils
     

--- a/guizero/RadioButton.py
+++ b/guizero/RadioButton.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Radiobutton
 
 from . import utilities as utils
 

--- a/guizero/Slider.py
+++ b/guizero/Slider.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Scale, HORIZONTAL, VERTICAL
 
 from . import utilities as utils
     

--- a/guizero/Text.py
+++ b/guizero/Text.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Label, StringVar
 
 from . import utilities as utils
     

--- a/guizero/TextBox.py
+++ b/guizero/TextBox.py
@@ -1,7 +1,4 @@
-try:
-    from tkinter import *
-except ImportError:
-    print("tkinter did not import successfully. Please check your setup.")
+from tkinter import Entry, StringVar
 
 from . import utilities as utils
     

--- a/guizero/__init__.py
+++ b/guizero/__init__.py
@@ -1,7 +1,9 @@
+from sys import exit
 try:
-    from tkinter import *
-except:
-    from Tkinter import *
+    from tkinter import Tk
+except ImportError:
+    print("tkinter did not import successfully. Please check your setup.")
+    exit(1)
 
 from . import utilities as utils
 from .alerts import *


### PR DESCRIPTION
Since we can check for import errors on the `__init__.py` file, there is no need to catch import exceptions in each file.
I've also modified the tkinter imports to included only what is required for each individual file, that way it only imports what it needs and it is more clear where things are coming from.