### PR TITLE
Fix scheduled function cancellation

### DIFF
--- a/guizero/tkmixins.py
+++ b/guizero/tkmixins.py
@@ -25,14 +25,15 @@ class ScheduleMixin():
         """Fired by tk.after, gets the callback and either executes the function and cancels or repeats"""
         # execute the function
         function(*args)
-        repeat = self._callback[function][1]
-        if repeat:
-            # setup the call back again and update the id
-            callback_id = self.tk.after(time, self._call_wrapper, time, function, *args)
-            self._callback[function][0] = callback_id
-        else:
-            # remove it from the call back dictionary
-            self._callback.pop(function)
+        if function in self._callback.keys():
+            repeat = self._callback[function][1]
+            if repeat:
+                # setup the call back again and update the id
+                callback_id = self.tk.after(time, self._call_wrapper, time, function, *args)
+                self._callback[function][0] = callback_id
+            else:
+                # remove it from the call back dictionary
+                self._callback.pop(function)
 
 class DestroyMixin():
     def destroy(self):


### PR DESCRIPTION
Cancelling a scheduled function that is running can result in an exception.
This can occur if the function cancels itself.
We can prevent this by checking if the function exists in self._callback