### PR TITLE
Multiline Text Widget

### DIFF
--- a/guizero/Text.py
+++ b/guizero/Text.py
@@ -1,15 +1,18 @@
-from tkinter import Label, StringVar
+from tkinter import Label, StringVar, Message
 from . import utilities as utils
 from .base import TextWidget
 
 class Text(TextWidget):
 
-    def __init__(self, master, text="", size=12, color="black", bg=None, font="Helvetica", grid=None, align=None, visible=True, enabled=None):
+    def __init__(self, master, text="", size=12, color="black", bg=None, font="Helvetica", grid=None, align=None, visible=True, enabled=None, multiline=False):
 
         description = "[Text] object with text \"" + str(text) + "\""
         
         self._text = str(text)
-        tk = Label(master.tk, text=text, fg=utils.convert_color(color), bg=utils.convert_color(bg), font=(font, size))
+        if multiline:
+            tk = Message(master.tk, text=text, fg=utils.convert_color(color), bg=utils.convert_color(bg), font=(font, size))
+        else:
+            tk = Label(master.tk, text=text, fg=utils.convert_color(color), bg=utils.convert_color(bg), font=(font, size))
 
         super(Text, self).__init__(master, tk, description, grid, align, visible, enabled)
 


### PR DESCRIPTION
The Textbox widget allows multiline entry using the tkinter Text widget rather than Entry. 
This request is to add multiline support to the guizero Text widget using the tkinter Message widget rather than Label.