### PR TITLE
Change parameter text_size to size

### DIFF
--- a/docs-src/docs/text.md
+++ b/docs-src/docs/text.md
@@ -46,7 +46,7 @@ When you create a `Text` object, you **must** specify a `master` and you can spe
 | color     | [color](colors.md) | black       | -          | The colour of the text. Accepts some colour strings (e.g. `red`) and colours specified in hex format (e.g. `#0099ff`) |
 | font      | string             | "Helvetica" | -          | The font face that the text will be displayed in. Availability of fonts depends on which fonts are installed locally. |
 | grid      | List [int, int]    | None        | -          | `[x,y]` coordinates of this widget. This parameter is only required if the `master` object has a grid layout.         |
-| text_size | int                | 12          | -          | The font size of the text                                                                                             |
+| size      | int                | 12          | -          | The font size of the text                                                                                             |
 | text      | string             | ""          | -          | The text you want to display                                                                                          |
 | visible   | boolean            | True        | No         | If the widget should be visible.                                                                                      |
 | enabled   | boolean            | None        | No         | If the widget should be enabled. If `None` (the default) the enabled property will be inherited from the master       |


### PR DESCRIPTION
The documentation currently states that there is a "text_size" parameter for the text widget, but the parameter actually is "size".