### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: python
+
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+      python: "3.7"
+      services: xvfb
+    - os: osx
+      osx_image: xcode11.2
+      # 'language: python' is an error on Travis CI macOS
+      # See https://docs.travis-ci.com/user/languages/python
+      language: shell
+
+install:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo Xvfb :99 -ac & fi
+  # Create and activate an isolated virtual environment
+  - pip3 install --upgrade virtualenv
+  - python3 -m virtualenv guizero-env
+  - source guizero-env/bin/activate
+  # Install test dependencies
+  - pip install --upgrade mkdocs wheel twine virtualenv pytest pillow
+  # Install `guizero` in "development mode"
+  - python setup.py develop
+  - cd tests
+
+script:
+  - pytest -v
+
+after_script:
+  # Clean up to test the full lifecycle
+  - cd ..
+  - python setup.py develop --uninstall
+  - deactivate
+  - rm -r guizero-env
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo pkill -SIGTERM Xvfb; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   # Install `guizero` in "development mode"
   - python setup.py develop
   - cd tests
+  - python -c 'import tkinter; print(tkinter.TclVersion)'
 
 script:
   - pytest -v


### PR DESCRIPTION
This pull request adds a configuration file for running continuous integration with Travis CI. It reproduces issue #345, as well as https://github.com/lawsie/guizero/issues/230#issuecomment-557830867. See [travis-ci.com/pzahemszky/guizero/jobs/259828319](https://travis-ci.com/pzahemszky/guizero/jobs/259828319) and [travis-ci.com/pzahemszky/guizero/jobs/259828318](https://travis-ci.com/pzahemszky/guizero/jobs/259828318).

I've marked it as a "Draft pull request" since it needs setup on the GitHub side first.