### PR TITLE
Update to Python 3 syntax

### DIFF
--- a/guizero/App.py
+++ b/guizero/App.py
@@ -8,13 +8,13 @@ class App(BaseWindow):
     _main_app = None
 
     def __init__(
-        self, 
-        title="guizero", 
-        width=500, 
-        height=500, 
-        layout="auto", 
-        bgcolor=None, 
-        bg=None, 
+        self,
+        title="guizero",
+        width=500,
+        height=500,
+        layout="auto",
+        bgcolor=None,
+        bg=None,
         visible=True):
 
         """
@@ -56,7 +56,7 @@ class App(BaseWindow):
             tk = Toplevel(App._main_app.tk)
             utils.error_format("There should only be 1 guizero App, use Window to create multiple windows.")
 
-        super(App, self).__init__(
+        super().__init__(
             None,
             tk,
             description,

--- a/guizero/Box.py
+++ b/guizero/Box.py
@@ -51,7 +51,7 @@ class Box(ContainerWidget):
             size. If not `None`, both the width and height need to be set.
 
         :param int border:
-            Sets the border thickness. `0` or `False` is no border. `True` or 
+            Sets the border thickness. `0` or `False` is no border. `True` or
             value > 1 sets a border. The default is `None`.
         """
 
@@ -59,7 +59,7 @@ class Box(ContainerWidget):
 
         tk = Frame(master.tk)
 
-        super(Box, self).__init__(master, tk, description, layout, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, layout, grid, align, visible, enabled, width, height)
 
         self.resize(width, height)
 
@@ -105,5 +105,5 @@ class Box(ContainerWidget):
             The height of the widget.
         """
         self._set_propagation(width, height)
-        
-        super(Box, self).resize(width, height)
+
+        super().resize(width, height)

--- a/guizero/ButtonGroup.py
+++ b/guizero/ButtonGroup.py
@@ -84,7 +84,7 @@ class ButtonGroup(ContainerTextWidget):
         self._selected = StringVar(master=tk.winfo_toplevel())
 
         # ButtonGroup uses "grid" internally to sort the RadioButtons
-        super(ButtonGroup, self).__init__(master, tk, description, "grid", grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, "grid", grid, align, visible, enabled, width, height)
 
         # Loop through the list given and setup the options
         self._options = []
@@ -207,7 +207,7 @@ class ButtonGroup(ContainerTextWidget):
         if len(self._rbuttons) > 0:
             # work out the height of a button
             button_height = height
-            
+
             if isinstance(height, int):
                 if height % len(self._rbuttons) != 0:
                     # if the height doesnt divide by the number of radio buttons give a warning
@@ -216,11 +216,11 @@ class ButtonGroup(ContainerTextWidget):
                     utils.error_format("ButtonGroup height '{}' doesn't divide by the number of buttons '{}' setting height to '{}'.".format(height, len(self._rbuttons), new_height))
                 else:
                     button_height = int(height / len(self._rbuttons))
-            
+
             for item in self._rbuttons:
                 item.height = button_height
 
-        super(ButtonGroup, self).resize(width, height)
+        super().resize(width, height)
 
     @property
     def options(self):
@@ -311,5 +311,3 @@ class ButtonGroup(ContainerTextWidget):
 
     def _command_callback(self):
         self._command()
-
- 

--- a/guizero/CheckBox.py
+++ b/guizero/CheckBox.py
@@ -61,7 +61,7 @@ class CheckBox(TextWidget):
         self._value = IntVar()
         tk = Checkbutton(master.tk, text=text, variable=self._value)
 
-        super(CheckBox, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         # Set the command callback
         self.tk.config(command=self._command_callback)

--- a/guizero/Combo.py
+++ b/guizero/Combo.py
@@ -11,7 +11,7 @@ class ComboMenu(Base, ColorMixin, TextMixin):
         Internal class for managing the little menu which pops up when the
         combo box is opened
         """
-        super(ComboMenu, self).__init__(tk)
+        super().__init__(tk)
 
 
 class Combo(TextWidget):
@@ -84,7 +84,7 @@ class Combo(TextWidget):
         # Create the combo menu object
         self._combo_menu = ComboMenu(tk["menu"])
 
-        super(Combo, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         # Remove the thick highlight when the bg is a different color
         self._set_tk_config("highlightthickness", 0)

--- a/guizero/Drawing.py
+++ b/guizero/Drawing.py
@@ -7,13 +7,13 @@ from .event import EventManager
 class Drawing(Widget):
 
     def __init__(
-        self, 
-        master, 
-        width=100, 
-        height=100, 
-        grid=None, 
-        align=None, 
-        visible=True, 
+        self,
+        master,
+        width=100,
+        height=100,
+        grid=None,
+        align=None,
+        visible=True,
         enabled=None):
         """
         Creates a Drawing
@@ -28,7 +28,7 @@ class Drawing(Widget):
         :param int height:
             The starting height of the widget. Defaults to `None` and will auto
             size.
-        
+
         :param List grid:
             Grid co-ordinates for the widget, required if the master layout
             is 'grid', defaults to `None`.
@@ -52,7 +52,7 @@ class Drawing(Widget):
 
         tk = Canvas(master.tk, height=100, width=100, bd=0, highlightthickness=0)
 
-        super(Drawing, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
     def line(self, x1, y1, x2, y2, color="black", width=1):
         """
@@ -80,7 +80,7 @@ class Drawing(Widget):
             The id of the line.
         """
         return self.tk.create_line(
-            x1, y1, x2, y2, 
+            x1, y1, x2, y2,
             width = width,
             fill = "" if color is None else utils.convert_color(color)
             )
@@ -114,7 +114,7 @@ class Drawing(Widget):
             The id of the shape.
         """
         return self.tk.create_oval(
-            x1, y1, x2, y2, 
+            x1, y1, x2, y2,
             outline = utils.convert_color(outline_color) if outline else "",
             width = int(outline),
             fill = "" if color is None else utils.convert_color(color)
@@ -149,7 +149,7 @@ class Drawing(Widget):
             The id of the shape.
         """
         return self.tk.create_rectangle(
-            x1, y1, x2, y2, 
+            x1, y1, x2, y2,
             outline = utils.convert_color(outline_color) if outline else "",
             width = int(outline),
             fill = "" if color is None else utils.convert_color(color)
@@ -175,7 +175,7 @@ class Drawing(Widget):
             The id of the shape.
         """
         return self.tk.create_polygon(
-            *coords, 
+            *coords,
             outline = utils.convert_color(outline_color) if outline else "",
             width = int(outline),
             fill = "" if color is None else utils.convert_color(color)
@@ -216,15 +216,15 @@ class Drawing(Widget):
             The id of the shape.
         """
         return self.polygon(
-            x1, y1, x2, y2, x3, y3, 
-            color=color, 
-            outline=outline, 
+            x1, y1, x2, y2, x3, y3,
+            color=color,
+            outline=outline,
             outline_color=outline_color)
 
     def image(self, x, y, image, width=None, height=None):
         """
         Inserts an image into the drawing, position by its top-left corner.
-        
+
         :param int x:
             The x position to insert the image.
 
@@ -239,7 +239,7 @@ class Drawing(Widget):
             actual width of the Image. Default to `None`.
 
         :param str height:
-            The width to scale the image too, setting to `None` will use the 
+            The width to scale the image too, setting to `None` will use the
             actual height of the Image. Default to `None`.
 
         :return:
@@ -250,11 +250,11 @@ class Drawing(Widget):
         id = self.tk.create_image(x, y, image=_image.tk_image, anchor="nw")
         self._images[id] = _image
         return id
-    
+
     def text(self, x, y, text, color="black", font=None, size=None, max_width=None):
         """
         Inserts text into the drawing, position by its top-left corner.
-        
+
         :param int x:
             The x position of the text.
 
@@ -273,7 +273,7 @@ class Drawing(Widget):
             default font size.
 
         :param int max_width:
-            Maximum line length. Lines longer than this value are wrapped. 
+            Maximum line length. Lines longer than this value are wrapped.
             Default is `None` (no wrapping).
         """
         # create the font
@@ -281,9 +281,9 @@ class Drawing(Widget):
             f = Font(self.tk, family=font)
         else:
             f = Font(self.tk, family=font, size=size)
-        
+
         return self.tk.create_text(
-            x, y, 
+            x, y,
             text=text,
             fill = "" if color is None else utils.convert_color(color),
             font=f,

--- a/guizero/ListBox.py
+++ b/guizero/ListBox.py
@@ -70,7 +70,7 @@ class ListBox(ContainerTextWidget):
 
         tk = Frame(master.tk)
 
-        super(ListBox, self).__init__(master, tk, description, "auto", grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, "auto", grid, align, visible, enabled, width, height)
 
         self._listbox = ListBoxWidget(self, items, selected, command, None, "left", visible, enabled, multiselect, None, None)
         self._listbox.resize("fill", "fill")
@@ -101,7 +101,7 @@ class ListBox(ContainerTextWidget):
         # size and you cant make the control smaller than that.
         self._listbox._set_tk_config("width", None if width is None else 0)
         self._set_propagation(width, height)
-        super(ListBox, self).resize(width, height)
+        super().resize(width, height)
 
     @property
     def value(self):
@@ -186,7 +186,7 @@ class ListBoxWidget(TextWidget):
             for item in items:
                 tk.insert(END, item)
 
-        super(ListBoxWidget, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         self.events.set_event("<ListBox.ListboxSelect>", "<<ListboxSelect>>", self._command_callback)
 

--- a/guizero/MenuBar.py
+++ b/guizero/MenuBar.py
@@ -22,7 +22,7 @@ class MenuBar(Component):
             A 3D list of:
                 - submenus,
                 - with each submenu being a list of options
-                - and each option being a text/command pair 
+                - and each option being a text/command pair
 
             e.g ::
 
@@ -40,7 +40,7 @@ class MenuBar(Component):
         # Create a tk Menu object within this object
         tk = Menu(master.tk)
 
-        super(MenuBar, self).__init__(master, tk, description, False)
+        super().__init__(master, tk, description, False)
 
         # Keep track of submenu objects
         self._sub_menus = []
@@ -68,8 +68,8 @@ class MenuBar(Component):
         """
         Sets the background color of the widget.
 
-        Note - some operating systems dont allow the background color of the 
-        menu bar to be changed. 
+        Note - some operating systems dont allow the background color of the
+        menu bar to be changed.
         """
         return super(MenuBar, self.__class__).bg.fget(self)
 
@@ -79,4 +79,3 @@ class MenuBar(Component):
         super(MenuBar, self.__class__).bg.fset(self, color)
         for sub_menu in self._sub_menus:
             sub_menu["bg"] = utils.convert_color(color)
-    

--- a/guizero/Picture.py
+++ b/guizero/Picture.py
@@ -5,14 +5,14 @@ from .base import Widget
 class Picture(Widget):
 
     def __init__(
-        self, 
-        master, 
-        image=None, 
-        grid=None, 
-        align=None, 
-        visible=True, 
-        enabled=None, 
-        width=None, 
+        self,
+        master,
+        image=None,
+        grid=None,
+        align=None,
+        visible=True,
+        enabled=None,
+        width=None,
         height=None):
 
         """
@@ -56,7 +56,7 @@ class Picture(Widget):
         # Instantiate label object which will contain image
         tk = Label(master.tk)
 
-        super(Picture, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         # create the image
         self._load_image()

--- a/guizero/PushButton.py
+++ b/guizero/PushButton.py
@@ -90,7 +90,7 @@ class PushButton(TextWidget):
         self._text.set(text)
         tk = Button(master.tk, textvariable=self._text, command=self._command_callback)
 
-        super(PushButton, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         # Add padding if necessary
         self.tk.config(pady=pady, padx=padx)

--- a/guizero/RadioButton.py
+++ b/guizero/RadioButton.py
@@ -18,7 +18,7 @@ class RadioButton(TextWidget):
         # unless they know what they are doing.
         tk = Radiobutton(master.tk, text=self._text, value=self._value, variable=variable)
 
-        super(RadioButton, self).__init__(master, tk, description, grid, align, visible, enabled, None, None)
+        super().__init__(master, tk, description, grid, align, visible, enabled, None, None)
 
     # PROPERTIES
     # -----------------------------------

--- a/guizero/Slider.py
+++ b/guizero/Slider.py
@@ -5,17 +5,17 @@ from .base import TextWidget
 class Slider(TextWidget):
 
     def __init__(
-        self, 
-        master, 
-        start=0, 
-        end=100, 
-        horizontal=True, 
-        command=None, 
-        grid=None, 
-        align=None, 
-        visible=True, 
-        enabled=None, 
-        width=None, 
+        self,
+        master,
+        start=0,
+        end=100,
+        horizontal=True,
+        command=None,
+        grid=None,
+        align=None,
+        visible=True,
+        enabled=None,
+        width=None,
         height=None):
 
         description = "[Slider] object from " + str(start) + " to " + str(end)
@@ -27,7 +27,7 @@ class Slider(TextWidget):
         # Create a tk Scale object within this object
         tk = Scale(master.tk, from_=start, to=end, orient=orient, command=self._command_callback)
 
-        super(Slider, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         self.update_command(command)
 
@@ -47,7 +47,7 @@ class Slider(TextWidget):
         self._set_height(height)
         if width == "fill" or height == "fill":
             self.master.display_widgets()
-    
+
     def _set_width(self, width):
         self._width = width
         if width != "fill":
@@ -55,7 +55,7 @@ class Slider(TextWidget):
                 self._set_tk_config("length", width)
             else:
                 self._set_tk_config("width", width)
-    
+
     def _set_height(self, height):
         self._height = height
         if height != "fill":

--- a/guizero/Text.py
+++ b/guizero/Text.py
@@ -23,12 +23,12 @@ class Text(TextWidget):
 
         self._text = str(text)
         tk = Label(master.tk, text=text)
-        super(Text, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         # setup defaults
         if bg:
             self.bg = bg
-        
+
         if size is not None:
             self.text_size = size
 
@@ -75,4 +75,3 @@ class Text(TextWidget):
         self._text = new_text
         self.tk.config(text=new_text)
         self.description = "[Text] object with text \"" + new_text + "\""
-

--- a/guizero/TextBox.py
+++ b/guizero/TextBox.py
@@ -23,7 +23,7 @@ class TextBox(TextWidget):
         description = "[TextBox] object with text \"" + str(text) + "\""
 
         self._multiline = multiline
-        
+
         # Set up controlling string variable
         self._text = StringVar()
         self._text.set( str(text) )
@@ -38,7 +38,7 @@ class TextBox(TextWidget):
         else:
             tk = Entry(master.tk, textvariable=self._text)
 
-        super(TextBox, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         self.hide_text = hide_text
         self.update_command(command)
@@ -93,7 +93,7 @@ class TextBox(TextWidget):
             show_value = ""
         else:
             show_value = value
-        
+
         self._set_tk_config("show", show_value)
 
     # METHODS
@@ -121,4 +121,3 @@ class TextBox(TextWidget):
     # Append text
     def append(self, text):
         self.value = self.value + str(text)
-

--- a/guizero/Waffle.py
+++ b/guizero/Waffle.py
@@ -278,7 +278,7 @@ class Waffle(Widget):
     def __getitem__(self, index):
         return self._waffle_pixels[index]
 
-class WafflePixel():
+class WafflePixel:
     def __init__(self, x, y, canvas, canvas_x, canvas_y, size, dotty, color):
         self._x = x
         self._y = y

--- a/guizero/Waffle.py
+++ b/guizero/Waffle.py
@@ -6,19 +6,19 @@ from .event import EventManager
 class Waffle(Widget):
 
     def __init__(
-        self, 
-        master, 
-        height=3, 
-        width=3, 
-        dim=20, 
-        pad=5, 
-        color="white", 
-        dotty=False, 
-        grid=None, 
-        align=None, 
-        command=None,  
-        visible=True, 
-        enabled=None, 
+        self,
+        master,
+        height=3,
+        width=3,
+        dim=20,
+        pad=5,
+        color="white",
+        dotty=False,
+        grid=None,
+        align=None,
+        command=None,
+        visible=True,
+        enabled=None,
         bg=None):
 
         description = "[Waffle] object ({}x{})".format(height, width)
@@ -35,7 +35,7 @@ class Waffle(Widget):
         self._waffle_pixels = {}
         self._canvas = None
 
-        super(Waffle, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         if bg is not None:
             self.bg = bg
@@ -56,7 +56,7 @@ class Waffle(Widget):
     def _create_waffle(self):
         if self._height == "fill" or self._width == "fill":
             utils.raise_error("{}\nCannot use 'fill' for width and height.".format(self.description))
-            
+
         self._create_canvas()
         self._size_waffle()
         self._draw_waffle()

--- a/guizero/Window.py
+++ b/guizero/Window.py
@@ -6,13 +6,13 @@ from . import utilities as utils
 class Window(BaseWindow):
 
     def __init__(
-        self, 
-        master, 
-        title="guizero", 
-        width=500, 
-        height=500, 
-        layout="auto", 
-        bg=None, 
+        self,
+        master,
+        title="guizero",
+        width=500,
+        height=500,
+        layout="auto",
+        bg=None,
         visible=True):
 
         description = "[Window] oject"
@@ -20,7 +20,7 @@ class Window(BaseWindow):
         self._modal = False
         tk = Toplevel(master.tk)
 
-        super(Window, self).__init__(
+        super().__init__(
             master,
             tk,
             description,

--- a/guizero/base.py
+++ b/guizero/base.py
@@ -111,7 +111,7 @@ class Component(
         """
         An abstract class for a component in guizero.
         """
-        super(Component, self).__init__(tk)
+        super().__init__(tk)
 
         self._master = master
         self._description = description
@@ -182,7 +182,7 @@ class Container(Component):
         """
         An abstract class for a container which can hold other widgets.
         """
-        super(Container, self).__init__(master, tk, description, displayable)
+        super().__init__(master, tk, description, displayable)
         self._children = []
         self._layout_manager = layout
         self._bg = None
@@ -445,7 +445,7 @@ class BaseWindow(Container):
         """
         Base class for objects which use windows e.g. `App` and `Window`
         """
-        super(BaseWindow, self).__init__(master, tk, description, layout, False)
+        super().__init__(master, tk, description, layout, False)
 
         # Initial setup
         self.tk.title( str(title) )
@@ -572,7 +572,7 @@ class BaseWindow(Container):
         self.tk.attributes("-fullscreen", False)
         self._full_screen = False
         self.events.remove_event("<FullScreen.Escape>")
-    
+
     def warn(self, title, text):
         dialog.warn(title, text, master=self)
 
@@ -613,7 +613,7 @@ class Widget(
         """
         The base class for a widget which is an interactable component e.g. `Picture`
         """
-        super(Widget, self).__init__(master,tk, description, True)
+        super().__init__(master,tk, description, True)
         self._update_grid(grid)
         self._update_align(align)
         self._width = width
@@ -639,7 +639,7 @@ class TextWidget(
         """
         The base class for a widget which contains or has text e.g. ``Text`, `PushButton`
         """
-        super(TextWidget, self).__init__(master, tk, description, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, grid, align, visible, enabled, width, height)
 
         #inherit from master
         self.text_color = master.text_color
@@ -658,7 +658,7 @@ class ContainerWidget(
         """
         The base class for a widget which is also a container e.g. `Box`, `ButtonGroup`
         """
-        super(ContainerWidget, self).__init__(master,tk, description, layout, True)
+        super().__init__(master,tk, description, layout, True)
         self._update_grid(grid)
         self._update_align(align)
         self._width = width
@@ -720,4 +720,4 @@ class ContainerTextWidget(
         The base class for a widget which is also a container and contains text
         e.g. `ButtonGroup`
         """
-        super(ContainerTextWidget, self).__init__(master, tk, description, layout, grid, align, visible, enabled, width, height)
+        super().__init__(master, tk, description, layout, grid, align, visible, enabled, width, height)

--- a/guizero/base.py
+++ b/guizero/base.py
@@ -18,7 +18,7 @@ from .event import EventManager
 from . import dialog
 from tkinter import BOTH, X, Y, YES
 
-class Base():
+class Base:
 
     def __init__(self, tk):
         """

--- a/guizero/tkmixins.py
+++ b/guizero/tkmixins.py
@@ -3,7 +3,7 @@ from tkinter.font import Font
 from tkinter import TclError
 
 
-class ScheduleMixin():
+class ScheduleMixin:
     _callback = {}
     def after(self, time, function, args = []):
         """Call `function` after `time` milliseconds."""
@@ -39,13 +39,13 @@ class ScheduleMixin():
         function(*args)
 
 
-class DestroyMixin():
+class DestroyMixin:
     def destroy(self):
         """Destroy the object."""
         self.tk.destroy()
 
 
-class EnableMixin():
+class EnableMixin:
     @property
     def enabled(self):
         state = self._get_tk_config("state")
@@ -67,13 +67,13 @@ class EnableMixin():
         self._set_tk_config("state", "normal")
 
 
-class FocusMixin():
+class FocusMixin:
     def focus(self):
         """Give focus to the widget."""
         self.tk.focus_set()
 
 
-class DisplayMixin():
+class DisplayMixin:
 
     @property
     def visible(self):
@@ -100,7 +100,7 @@ class DisplayMixin():
         self.master.display_widgets()
 
 
-class TextMixin():
+class TextMixin:
 
     FG_KEYS = [
         "fg",
@@ -166,7 +166,7 @@ class TextMixin():
         self._set_tk_config("font", (self.font, size))
 
 
-class ColorMixin():
+class ColorMixin:
 
     # these are the widget keys which will get set when the background is changed
     BG_KEYS = [
@@ -190,7 +190,7 @@ class ColorMixin():
         self._set_tk_config(self.BG_KEYS, utils.convert_color(color))
 
 
-class SizeMixin():
+class SizeMixin:
     @property
     def width(self):
         """
@@ -233,7 +233,7 @@ class SizeMixin():
             self.master.display_widgets()
 
 
-class LayoutMixin():
+class LayoutMixin:
 
     @property
     def grid(self):
@@ -297,7 +297,7 @@ class LayoutMixin():
                 ))
 
 
-class EventsMixin():
+class EventsMixin:
 
     @property
     def when_clicked(self):

--- a/guizero/utilities.py
+++ b/guizero/utilities.py
@@ -19,7 +19,7 @@ class GUIZeroException(Exception):
     pass
 
 # holds details about the configuration guizero is using
-class SystemConfig():
+class SystemConfig:
     def __init__(self):
         """
         Holds details about the system configuration guizero is using
@@ -36,7 +36,7 @@ class SystemConfig():
                 # macOS only supports GIF with PIL
                 self._supported_image_types = ["GIF"]
 
-        # tk options  
+        # tk options
         self._tk_options = {
             "*Label.Font": "helvetica 12",
             "*Label.Foreground": "black",
@@ -70,7 +70,7 @@ class SystemConfig():
         Returns a dictionary of tk options in the format {"pattern": value}
         which will be applied when an App is created.
 
-        The tk options can be used to modify the default behaviour of 
+        The tk options can be used to modify the default behaviour of
         tk and its widgets e.g. Change the background colour of all Buttons ::
 
             from guizero import system_config
@@ -82,7 +82,7 @@ class SystemConfig():
 system_config = SystemConfig()
 
 
-class GUIZeroImage():
+class GUIZeroImage:
     def __init__(self, image_source, width, height):
         """
         GUIZeroImage manages an "image" for guizero widgets, parsing its
@@ -250,7 +250,7 @@ class GUIZeroImage():
                 self._animation = True
 
 
-class AnimationPlayer():
+class AnimationPlayer:
     def __init__(self, master, guizero_image, update_image_callback):
         """
         AnimationPlayer manages the playing of a animated gif for guizero
@@ -320,7 +320,7 @@ class TriggeredList(MutableSequence):
         """
         A list which will call a callback when a value is changed.
 
-        Used to hold a widgets grid reference.  
+        Used to hold a widgets grid reference.
         """
         self._list = list(iterable)
         self._on_change = on_change
@@ -397,7 +397,7 @@ def deprecated(message):
 
 def convert_color(color):
     """
-    Converts a color from "color", (255, 255, 255) or "#ffffff" into a color tk 
+    Converts a color from "color", (255, 255, 255) or "#ffffff" into a color tk
     should understand.
     """
     if color is not None:


### PR DESCRIPTION
Not hugely important or impactful but...

```python
super(ClassName, self).method()
```

can be replaced with:


```python
super().method()
```

and

```python
class ClassName():
```

can be replaced with:

```python
class ClassName:
```

¯\_(ツ)_/¯