### PR TITLE
Fixes a code example in the box widget documentation

### DIFF
--- a/docs-src/docs/box.md
+++ b/docs-src/docs/box.md
@@ -99,8 +99,8 @@ A `Box` object is invisible, but it can contain other widgets. In this example, 
 from guizero import App, Box, Text
 app = App(title="My app", height=300, width=400)
 box = Box(app)
-text1 = Text(box, text="Hello from the box", size=14, text_color="red", font="Arial")
-text2 = Text(app, text="Hello from the app", size=14, text_color="blue", font="Courier New")
+text1 = Text(box, text="Hello from the box", size=14, color="red", font="Arial")
+text2 = Text(app, text="Hello from the app", size=14, color="blue", font="Courier New")
 app.display()
 ```
 

--- a/docs/box/index.html
+++ b/docs/box/index.html
@@ -650,8 +650,8 @@ app.display()
 <pre><code class="language-python">from guizero import App, Box, Text
 app = App(title=&quot;My app&quot;, height=300, width=400)
 box = Box(app)
-text1 = Text(box, text=&quot;Hello from the box&quot;, size=14, text_color=&quot;red&quot;, font=&quot;Arial&quot;)
-text2 = Text(app, text=&quot;Hello from the app&quot;, size=14, text_color=&quot;blue&quot;, font=&quot;Courier New&quot;)
+text1 = Text(box, text=&quot;Hello from the box&quot;, size=14, color=&quot;red&quot;, font=&quot;Arial&quot;)
+text2 = Text(app, text=&quot;Hello from the app&quot;, size=14, color=&quot;blue&quot;, font=&quot;Courier New&quot;)
 app.display()
 </code></pre>
 <p><img alt="Box and app" src="../images/box-app.png" /></p>


### PR DESCRIPTION
Example code from https://lawsie.github.io/guizero/box/ does not run when copy/pasted into a file and executed:
```python
from guizero import App, Box, Text
app = App(title="My app", height=300, width=400)
box = Box(app)
text1 = Text(box, text="Hello from the box", size=14, text_color="red", font="Arial")
text2 = Text(app, text="Hello from the app", size=14, text_color="blue", font="Courier New")
app.display()
```
Causes:
```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    text1 = Text(box, text="Hello from the box", size=14, text_color="red", font="Arial")
TypeError: __init__() got an unexpected keyword argument 'text_color'
```
The Text widget init is:
```python
__init__(
    self,
    master,
    text="",
    size=12,
    color="black", # note: color, not text_color
    bg=None,
    font="Helvetica",
    grid=None,
    align=None,
    visible=True,
    enabled=None,
    width=None,
    height=None)
```

This change updates the documentation example code.